### PR TITLE
multiple collections per document

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,18 @@ Adds a `path` property to the collection item's data which contains the file pat
 <h1><a href="/{{ path }}">{{ title }}</a></h1>
 ```
 
+You can also assign multiple collections by comma-separating the list:
+```markdown
+---
+title: My Article
+collection: articles, featured
+date: 2013-02-21
+---
+
+My article contents...
+```
+
+
 ### Collection Metadata
 
 Additional metadata can be added to the collection object.

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,16 +36,20 @@ function plugin(opts){
       debug('checking file: %s', file);
       var data = files[file];
 
-      data.path = file
+      data.path = file;
 
       match(file, data).forEach(function(key){
-        if (key && keys.indexOf(key) < 0){
-          opts[key] = {};
-          keys.push(key);
-        }
+        var terms = key.split(',');
+        for(var i = 0; i < terms.length; i++) {
+            var term = terms[i].trim();
+            if (term && keys.indexOf(term) < 0) {
+                opts[term] = {};
+                keys.push(term);
+            }
 
-        metadata[key] = metadata[key] || [];
-        metadata[key].push(data);
+            metadata[term] = metadata[term] || [];
+            metadata[term].push(data);
+        }
       });
     });
 


### PR DESCRIPTION
multiple collections can be assigned to a document by adding a comma-separated list of collections in metadata